### PR TITLE
Add iOS framework support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 IBANtools.xcodeproj/project.xcworkspace/xcuserdata
 IBANtools.xcodeproj/xcuserdata
+.DS_Store

--- a/IBANtools.xcodeproj/project.pbxproj
+++ b/IBANtools.xcodeproj/project.pbxproj
@@ -17,6 +17,17 @@
 		27AFAF051C5E63C8002A7C50 /* Transformers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AFAF041C5E63C8002A7C50 /* Transformers.swift */; };
 		27B094B91AB4634300FA3D6D /* eu_all_mfi.txt in Resources */ = {isa = PBXBuildFile; fileRef = 27B094B81AB4634300FA3D6D /* eu_all_mfi.txt */; };
 		27BB86871A3DCCA4005317B2 /* IBANtoolsDETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BB86861A3DCCA4005317B2 /* IBANtoolsDETests.swift */; };
+		D7355C3B23EDB427006010AF /* IBANtools_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7355C3223EDB427006010AF /* IBANtools_iOS.framework */; };
+		D7355C4223EDB427006010AF /* IBANtools_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = D7355C3423EDB427006010AF /* IBANtools_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D7355C5223EDB47C006010AF /* Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A840CB1A33443F00B78076 /* Converter.swift */; };
+		D7355C5323EDB47F006010AF /* DERules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27428E271A3DBBAF00DC3DB3 /* DERules.swift */; };
+		D7355C5423EDB48D006010AF /* DEAccountCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2775C2241A45B8E100F912C1 /* DEAccountCheck.swift */; };
+		D7355C5523EDB495006010AF /* Transformers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AFAF041C5E63C8002A7C50 /* Transformers.swift */; };
+		D7355C5623EDB8C9006010AF /* IBANtoolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A840C11A33442700B78076 /* IBANtoolsTests.swift */; };
+		D7355C5723EDB8CB006010AF /* IBANtoolsDETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BB86861A3DCCA4005317B2 /* IBANtoolsDETests.swift */; };
+		D7355C5823EDB8CE006010AF /* AccountCheckDETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2775C2261A45BA7E00F912C1 /* AccountCheckDETests.swift */; };
+		D7355C5923EDB955006010AF /* eu_all_mfi.txt in Resources */ = {isa = PBXBuildFile; fileRef = 27B094B81AB4634300FA3D6D /* eu_all_mfi.txt */; };
+		D7355C5A23EDB95C006010AF /* de in Resources */ = {isa = PBXBuildFile; fileRef = 278980671A4094F300C2495F /* de */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,6 +37,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 27A840AE1A33442700B78076;
 			remoteInfo = IBANtools;
+		};
+		D7355C3C23EDB427006010AF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 27A840A61A33442600B78076 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D7355C3123EDB427006010AF;
+			remoteInfo = IBANtools_iOS;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -43,6 +61,11 @@
 		27AFAF041C5E63C8002A7C50 /* Transformers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Transformers.swift; path = Source/Transformers.swift; sourceTree = SOURCE_ROOT; wrapsLines = 0; };
 		27B094B81AB4634300FA3D6D /* eu_all_mfi.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = eu_all_mfi.txt; path = Resources/eu_all_mfi.txt; sourceTree = "<group>"; };
 		27BB86861A3DCCA4005317B2 /* IBANtoolsDETests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IBANtoolsDETests.swift; path = Tests/IBANtoolsDETests.swift; sourceTree = SOURCE_ROOT; wrapsLines = 0; };
+		D7355C3223EDB427006010AF /* IBANtools_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IBANtools_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7355C3423EDB427006010AF /* IBANtools_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IBANtools_iOS.h; sourceTree = "<group>"; };
+		D7355C3523EDB427006010AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D7355C3A23EDB427006010AF /* IBANtools_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IBANtools_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7355C4123EDB427006010AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +81,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				27A840BB1A33442700B78076 /* IBANtools.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C2F23EDB427006010AF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C3723EDB427006010AF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7355C3B23EDB427006010AF /* IBANtools_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,6 +117,8 @@
 				278980661A4094C200C2495F /* Resources */,
 				27A840B11A33442700B78076 /* Source */,
 				27A840BE1A33442700B78076 /* Tests */,
+				D7355C3323EDB427006010AF /* IBANtools_iOS */,
+				D7355C3E23EDB427006010AF /* IBANtools_iOSTests */,
 				27A840B01A33442700B78076 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -88,6 +128,8 @@
 			children = (
 				27A840AF1A33442700B78076 /* IBANtools.framework */,
 				27A840BA1A33442700B78076 /* IBANtoolsTests.xctest */,
+				D7355C3223EDB427006010AF /* IBANtools_iOS.framework */,
+				D7355C3A23EDB427006010AF /* IBANtools_iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -131,6 +173,23 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		D7355C3323EDB427006010AF /* IBANtools_iOS */ = {
+			isa = PBXGroup;
+			children = (
+				D7355C3423EDB427006010AF /* IBANtools_iOS.h */,
+				D7355C3523EDB427006010AF /* Info.plist */,
+			);
+			path = IBANtools_iOS;
+			sourceTree = "<group>";
+		};
+		D7355C3E23EDB427006010AF /* IBANtools_iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				D7355C4123EDB427006010AF /* Info.plist */,
+			);
+			path = IBANtools_iOSTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -138,6 +197,14 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C2D23EDB427006010AF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7355C4223EDB427006010AF /* IBANtools_iOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -180,6 +247,42 @@
 			productReference = 27A840BA1A33442700B78076 /* IBANtoolsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D7355C3123EDB427006010AF /* IBANtools_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D7355C4723EDB427006010AF /* Build configuration list for PBXNativeTarget "IBANtools_iOS" */;
+			buildPhases = (
+				D7355C2D23EDB427006010AF /* Headers */,
+				D7355C2E23EDB427006010AF /* Sources */,
+				D7355C2F23EDB427006010AF /* Frameworks */,
+				D7355C3023EDB427006010AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IBANtools_iOS;
+			productName = IBANtools_iOS;
+			productReference = D7355C3223EDB427006010AF /* IBANtools_iOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D7355C3923EDB427006010AF /* IBANtools_iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D7355C4823EDB427006010AF /* Build configuration list for PBXNativeTarget "IBANtools_iOSTests" */;
+			buildPhases = (
+				D7355C3623EDB427006010AF /* Sources */,
+				D7355C3723EDB427006010AF /* Frameworks */,
+				D7355C3823EDB427006010AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D7355C3D23EDB427006010AF /* PBXTargetDependency */,
+			);
+			name = IBANtools_iOSTests;
+			productName = IBANtools_iOSTests;
+			productReference = D7355C3A23EDB427006010AF /* IBANtools_iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -187,7 +290,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 1120;
 				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = "Mike Lischke";
 				TargetAttributes = {
@@ -198,6 +301,14 @@
 					27A840B91A33442700B78076 = {
 						CreatedOnToolsVersion = 6.1.1;
 						LastSwiftMigration = 1030;
+					};
+					D7355C3123EDB427006010AF = {
+						CreatedOnToolsVersion = 11.2.1;
+						ProvisioningStyle = Automatic;
+					};
+					D7355C3923EDB427006010AF = {
+						CreatedOnToolsVersion = 11.2.1;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -216,6 +327,8 @@
 			targets = (
 				27A840AE1A33442700B78076 /* IBANtools */,
 				27A840B91A33442700B78076 /* IBANtoolsTests */,
+				D7355C3123EDB427006010AF /* IBANtools_iOS */,
+				D7355C3923EDB427006010AF /* IBANtools_iOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -231,6 +344,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		27A840B81A33442700B78076 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C3023EDB427006010AF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7355C5923EDB955006010AF /* eu_all_mfi.txt in Resources */,
+				D7355C5A23EDB95C006010AF /* de in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C3823EDB427006010AF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -261,6 +390,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D7355C2E23EDB427006010AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7355C5423EDB48D006010AF /* DEAccountCheck.swift in Sources */,
+				D7355C5323EDB47F006010AF /* DERules.swift in Sources */,
+				D7355C5223EDB47C006010AF /* Converter.swift in Sources */,
+				D7355C5523EDB495006010AF /* Transformers.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D7355C3623EDB427006010AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7355C5723EDB8CB006010AF /* IBANtoolsDETests.swift in Sources */,
+				D7355C5623EDB8C9006010AF /* IBANtoolsTests.swift in Sources */,
+				D7355C5823EDB8CE006010AF /* AccountCheckDETests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -268,6 +418,11 @@
 			isa = PBXTargetDependency;
 			target = 27A840AE1A33442700B78076 /* IBANtools */;
 			targetProxy = 27A840BC1A33442700B78076 /* PBXContainerItemProxy */;
+		};
+		D7355C3D23EDB427006010AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D7355C3123EDB427006010AF /* IBANtools_iOS */;
+			targetProxy = D7355C3C23EDB427006010AF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -469,6 +624,122 @@
 			};
 			name = Release;
 		};
+		D7355C4323EDB427006010AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = IBANtools_iOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mike.lischke.IBANtools-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D7355C4423EDB427006010AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = IBANtools_iOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mike.lischke.IBANtools-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D7355C4523EDB427006010AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = IBANtools_iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mike.lischke.IBANtools-iOS.IBANtools-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D7355C4623EDB427006010AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = IBANtools_iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "mike.lischke.IBANtools-iOS.IBANtools-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -495,6 +766,24 @@
 			buildConfigurations = (
 				27A840C91A33442700B78076 /* Debug */,
 				27A840CA1A33442700B78076 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D7355C4723EDB427006010AF /* Build configuration list for PBXNativeTarget "IBANtools_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D7355C4323EDB427006010AF /* Debug */,
+				D7355C4423EDB427006010AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D7355C4823EDB427006010AF /* Build configuration list for PBXNativeTarget "IBANtools_iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D7355C4523EDB427006010AF /* Debug */,
+				D7355C4623EDB427006010AF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/IBANtools_iOS/IBANtools_iOS.h
+++ b/IBANtools_iOS/IBANtools_iOS.h
@@ -1,0 +1,19 @@
+//
+//  IBANtools_iOS.h
+//  IBANtools_iOS
+//
+//  Created by Eddie Long on 07/02/2020.
+//  Copyright © 2020 Mike Lischke. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for IBANtools_iOS.
+FOUNDATION_EXPORT double IBANtools_iOSVersionNumber;
+
+//! Project version string for IBANtools_iOS.
+FOUNDATION_EXPORT const unsigned char IBANtools_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <IBANtools_iOS/PublicHeader.h>
+
+

--- a/IBANtools_iOS/Info.plist
+++ b/IBANtools_iOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/IBANtools_iOSTests/Info.plist
+++ b/IBANtools_iOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Source/Converter.swift
+++ b/Source/Converter.swift
@@ -18,7 +18,6 @@
  */
 
 import Foundation
-import AppKit
 
 @objc public enum IBANToolsResult: Int {
   case defaultIBAN // The default rule for generating an IBAN was used.
@@ -204,9 +203,7 @@ open class IBANtools: NSObject {
         }
       }
       catch let error as NSError {
-        let alert = NSAlert.init(error: error);
-        alert.runModal();
-        return;
+        fatalError("Unable to load eu_all_mfi.txt with error \(error)")
       }
     }
   }

--- a/Source/Converter.swift
+++ b/Source/Converter.swift
@@ -141,69 +141,64 @@ open class IBANtools: NSObject {
 
   fileprivate class func loadData(_ path: String) {
     if FileManager.default.fileExists(atPath: path + "/eu_all_mfi.txt") {
-      do {
-        let content = try NSString(contentsOfFile: path + "/eu_all_mfi.txt", encoding: String.Encoding.utf8.rawValue);
-        let bundle = Bundle(for: IBANtools.self);
+      guard let content = try? NSString(contentsOfFile: path + "/eu_all_mfi.txt", encoding: String.Encoding.utf8.rawValue) else { /* TODO: Return an error code */ return }
+      let bundle = Bundle(for: IBANtools.self);
 
-        usedPath = path + "/eu_all_mfi.txt";
-        _institutesInfo = [:];
+      usedPath = path + "/eu_all_mfi.txt";
+      _institutesInfo = [:];
 
-        // Extract institute details.
-        for line in content.components(separatedBy: CharacterSet.newlines) {
-          let s: NSString = line as NSString;
-          let entry = s.components(separatedBy: "\t") ;
-          if entry.count == 0 {
-            continue;
-          }
-          if entry[0] == "MFI_ID" {
-            continue; // Header line.
-          }
-
-          // The ECB MFI file doesn't contain PIN/TAN URLs or HBCI/FinTS version numbers used
-          // by a specific bank, so we ask the country specific classes for that info.
-          // This can potentially return invalid info, if there are multiple bank codes for the given BIC
-          // with different online details (in that case the last loaded record is returned).
-          var hbciVersion = "";
-          var pinTanVersion = "";
-          var hostURL = "";
-          var pinTanURL = "";
-          if let clazz: AnyClass = bundle.classNamed(entry[2] + "Rules"), entry[1].count > 0 {
-            let rulesClass = clazz as! IBANRules.Type;
-            (hbciVersion, pinTanVersion, hostURL, pinTanURL) = rulesClass.onlineDetailsForBIC(entry[1]);
-          }
-
-          let info = InstituteInfo();
-          info.mfiID = entry[0];
-          info.bic = entry[1];
-          info.countryCode = entry[2];
-          info.name = entry[3];
-          info.box = entry[4]
-          info.address = entry[5];
-          info.postal = entry[6];
-          info.city = entry[7];
-          info.category = entry[8];
-          info.domicile = entry[9];
-          info.headName = entry[11];
-          info.reserve = entry[12] == "Yes";
-          info.exempt = entry[13] == "Yes";
-
-          info.hbciVersion = hbciVersion;
-          info.pinTanVersion = pinTanVersion;
-          info.hostURL = hostURL;
-          info.pinTanURL = pinTanURL;
-
-          // Many entries in the file have no BIC and a few use the same BIC. In both cases
-          // we use the MFI ID instead (which is unique). We may later find a way to get the MFI ID
-          // from a BIC.
-          var key = entry[1].count > 0 ? entry[1] : entry[0];
-          if _institutesInfo[key] != nil {
-            key = entry[0];
-          }
-          _institutesInfo[key] = info; // Info keyed by BIC or (if the bic is empty/duplicate) by MFI ID.
+      // Extract institute details.
+      for line in content.components(separatedBy: CharacterSet.newlines) {
+        let s: NSString = line as NSString;
+        let entry = s.components(separatedBy: "\t") ;
+        if entry.count == 0 {
+          continue;
         }
-      }
-      catch let error as NSError {
-        fatalError("Unable to load eu_all_mfi.txt with error \(error)")
+        if entry[0] == "MFI_ID" {
+          continue; // Header line.
+        }
+
+        // The ECB MFI file doesn't contain PIN/TAN URLs or HBCI/FinTS version numbers used
+        // by a specific bank, so we ask the country specific classes for that info.
+        // This can potentially return invalid info, if there are multiple bank codes for the given BIC
+        // with different online details (in that case the last loaded record is returned).
+        var hbciVersion = "";
+        var pinTanVersion = "";
+        var hostURL = "";
+        var pinTanURL = "";
+        if let clazz: AnyClass = bundle.classNamed(entry[2] + "Rules"), entry[1].count > 0 {
+          let rulesClass = clazz as! IBANRules.Type;
+          (hbciVersion, pinTanVersion, hostURL, pinTanURL) = rulesClass.onlineDetailsForBIC(entry[1]);
+        }
+
+        let info = InstituteInfo();
+        info.mfiID = entry[0];
+        info.bic = entry[1];
+        info.countryCode = entry[2];
+        info.name = entry[3];
+        info.box = entry[4]
+        info.address = entry[5];
+        info.postal = entry[6];
+        info.city = entry[7];
+        info.category = entry[8];
+        info.domicile = entry[9];
+        info.headName = entry[11];
+        info.reserve = entry[12] == "Yes";
+        info.exempt = entry[13] == "Yes";
+
+        info.hbciVersion = hbciVersion;
+        info.pinTanVersion = pinTanVersion;
+        info.hostURL = hostURL;
+        info.pinTanURL = pinTanURL;
+
+        // Many entries in the file have no BIC and a few use the same BIC. In both cases
+        // we use the MFI ID instead (which is unique). We may later find a way to get the MFI ID
+        // from a BIC.
+        var key = entry[1].count > 0 ? entry[1] : entry[0];
+        if _institutesInfo[key] != nil {
+          key = entry[0];
+        }
+        _institutesInfo[key] = info; // Info keyed by BIC or (if the bic is empty/duplicate) by MFI ID.
       }
     }
   }

--- a/Source/DEAccountCheck.swift
+++ b/Source/DEAccountCheck.swift
@@ -18,7 +18,6 @@
  */
 
 import Foundation
-import AppKit
 
 @objc(DEAccountCheck)
 internal class DEAccountCheck : AccountCheck {
@@ -459,9 +458,7 @@ internal class DEAccountCheck : AccountCheck {
           }
         }
       } catch let error as NSError {
-        let alert = NSAlert.init(error: error);
-        alert.runModal();
-        return;
+        fatalError("Unable to load bundle: \(error)")
       }
     }
   }
@@ -1904,7 +1901,7 @@ internal class DEAccountCheck : AccountCheck {
   }
 
   private class func method68(_ number: [UInt16]) -> Bool {
-    var number = number
+    let number = number
     if number.count == 9 && number[0] == 4 {
       return true;
     }
@@ -2088,7 +2085,7 @@ internal class DEAccountCheck : AccountCheck {
     }
 
     // Code for method 52 and 53 differes only in handling for 8 and 9 digit account numbers.
-    var temp = [UInt16](bankCode.utf16);
+    let temp = [UInt16](bankCode.utf16);
     var eserAccount: [UInt16] = [];
     for n in temp[temp.count - 4..<temp.count] {
       eserAccount.append(n - 48);

--- a/Source/DEAccountCheck.swift
+++ b/Source/DEAccountCheck.swift
@@ -320,145 +320,141 @@ internal class DEAccountCheck : AccountCheck {
 
   override class func loadData(_ path: String) {
     if FileManager.default.fileExists(atPath: path + "/mappings.txt") {
-      do {
-        let content = try NSString(contentsOfFile: path + "/mappings.txt", encoding: String.Encoding.utf8.rawValue);
+      guard let content = try? NSString(contentsOfFile: path + "/mappings.txt", encoding: String.Encoding.utf8.rawValue) else { /* TODO: Return an error code */ return }
 
-        _mappings = [:];
+      _mappings = [:];
 
-        var sourceBankCode: NSString = "";
-        var rule = 0;
-        var entry: MappingDetails = (0, 0, 0, 0);
+      var sourceBankCode: NSString = "";
+      var rule = 0;
+      var entry: MappingDetails = (0, 0, 0, 0);
 
-        var sourceBankCodeIndex = -1;
-        var sourceAccountIndex = -1;
-        var sourceAccountStartIndex = -1;
-        var sourceAccountEndIndex = -1;
-        var targetBankCodeIndex = -1;
-        var targetAccountIndex = -1;
+      var sourceBankCodeIndex = -1;
+      var sourceAccountIndex = -1;
+      var sourceAccountStartIndex = -1;
+      var sourceAccountEndIndex = -1;
+      var targetBankCodeIndex = -1;
+      var targetAccountIndex = -1;
 
-        for line in content.components(separatedBy: CharacterSet.newlines) {
-          var s: NSString = line as NSString;
-          s = s.trimmingCharacters(in: CharacterSet.whitespaces) as NSString;
-          if s.length == 0 || s.hasPrefix("//")  || s.hasPrefix("#"){
-            continue; // Ignore empty and comment lines.
-          }
-
-          if s.hasPrefix("[") {
-            // Format specifier.
-            entry = (0, 0, 0, 0);
-            sourceBankCodeIndex = -1;
-            sourceAccountIndex = -1;
-            sourceAccountStartIndex = -1;
-            sourceAccountEndIndex = -1;
-            targetBankCodeIndex = -1;
-            targetAccountIndex = -1;
-
-            s = s.substring(with: NSMakeRange(1, s.length - 2)) as NSString;
-            var index = 0;
-            for part in s.components(separatedBy: CharacterSet.whitespaces) {
-              let p = part as NSString;
-              if !p.hasPrefix("#") && p != "_" {
-                rule = Int(part)!;
-                continue;
-              }
-
-              if p == "_" {
-                index += 1;
-                continue;
-              }
-
-              let explicitValue = p.substring(from: 3) as NSString;
-              switch p.substring(to: 3) {
-              case "#sc":
-                if explicitValue.length > 0 {
-                  sourceBankCode = (explicitValue as NSString);
-                  sourceBankCodeIndex = -1;
-                } else {
-                  sourceBankCodeIndex = index; index += 1;
-                }
-              case "#sa":
-                if explicitValue.length > 0 {
-                  entry.rangeStart = Int((explicitValue as String))!;
-                  entry.rangeEnd = entry.rangeStart;
-                  sourceAccountIndex = -1;
-                } else {
-                  sourceAccountIndex = index; index += 1;
-                }
-              case "#ss":
-                if explicitValue.length > 0 {
-                  entry.rangeStart = Int(explicitValue as String)!;
-                  sourceAccountStartIndex = -1;
-                } else {
-                  sourceAccountStartIndex = index; index += 1;
-                }
-              case "#se":
-                if explicitValue.length > 0 {
-                  entry.rangeEnd = Int(explicitValue as String)!;
-                  sourceAccountEndIndex = -1;
-                } else {
-                  sourceAccountEndIndex = index; index += 1;
-                }
-              case "#tc":
-                if explicitValue.length > 0 {
-                  entry.bankCode = Int(explicitValue as String)!;
-                  targetBankCodeIndex = -1;
-                } else {
-                  targetBankCodeIndex = index; index += 1;
-                }
-              case "#ta":
-                if explicitValue.length > 0 {
-                  entry.account = Int(explicitValue as String)!;
-                  targetAccountIndex = -1;
-                } else {
-                  targetAccountIndex = index; index += 1;
-                }
-
-              default:
-                index += 1;
-                continue;
-              }
-            }
-
-            continue;
-          }
-
-          // Normal mapping line.
-          let parts: [String] = s.components(separatedBy: CharacterSet.whitespaces) ;
-          if sourceBankCodeIndex > -1 && sourceBankCodeIndex < parts.count {
-            sourceBankCode = parts[sourceBankCodeIndex] as NSString;
-          }
-          if sourceAccountIndex > -1 && sourceAccountIndex < parts.count {
-            entry.rangeStart = Int(parts[sourceAccountIndex])!;
-            entry.rangeEnd = entry.rangeStart;
-          }
-          if sourceAccountStartIndex > -1 && sourceAccountStartIndex < parts.count {
-            entry.rangeStart = Int(parts[sourceAccountStartIndex])!;
-          }
-          if sourceAccountEndIndex > -1 && sourceAccountEndIndex < parts.count {
-            entry.rangeEnd = Int(parts[sourceAccountEndIndex])!;
-          }
-          if targetBankCodeIndex > -1 && targetBankCodeIndex < parts.count {
-            entry.bankCode = Int(parts[targetBankCodeIndex])!;
-          }
-          if targetAccountIndex > -1 && targetAccountIndex < parts.count {
-            entry.account = Int(parts[targetAccountIndex])!;
-          }
-
-          // There can never be multiple IBAN rules for a given bank code as every bank code is
-          // covered by exactly one rule (or none at all).
-          // The source bank code can actually be a list of bank codes.
-          for bankCode in sourceBankCode.components(separatedBy: ",") {
-            let code = Int(bankCode)!;
-            var mappingTuple = _mappings[code];
-            if mappingTuple == nil {
-              mappingTuple = (rule, []);
-            }
-            mappingTuple!.details.append(entry);
-            _mappings[code] = mappingTuple;
-          }
+      for line in content.components(separatedBy: CharacterSet.newlines) {
+        var s: NSString = line as NSString;
+        s = s.trimmingCharacters(in: CharacterSet.whitespaces) as NSString;
+        if s.length == 0 || s.hasPrefix("//")  || s.hasPrefix("#"){
+          continue; // Ignore empty and comment lines.
         }
-      } catch let error as NSError {
-        fatalError("Unable to load bundle: \(error)")
+
+        if s.hasPrefix("[") {
+          // Format specifier.
+          entry = (0, 0, 0, 0);
+          sourceBankCodeIndex = -1;
+          sourceAccountIndex = -1;
+          sourceAccountStartIndex = -1;
+          sourceAccountEndIndex = -1;
+          targetBankCodeIndex = -1;
+          targetAccountIndex = -1;
+
+          s = s.substring(with: NSMakeRange(1, s.length - 2)) as NSString;
+          var index = 0;
+          for part in s.components(separatedBy: CharacterSet.whitespaces) {
+            let p = part as NSString;
+            if !p.hasPrefix("#") && p != "_" {
+              rule = Int(part)!;
+              continue;
+            }
+
+            if p == "_" {
+              index += 1;
+              continue;
+            }
+
+            let explicitValue = p.substring(from: 3) as NSString;
+            switch p.substring(to: 3) {
+            case "#sc":
+              if explicitValue.length > 0 {
+                sourceBankCode = (explicitValue as NSString);
+                sourceBankCodeIndex = -1;
+              } else {
+                sourceBankCodeIndex = index; index += 1;
+              }
+            case "#sa":
+              if explicitValue.length > 0 {
+                entry.rangeStart = Int((explicitValue as String))!;
+                entry.rangeEnd = entry.rangeStart;
+                sourceAccountIndex = -1;
+              } else {
+                sourceAccountIndex = index; index += 1;
+              }
+            case "#ss":
+              if explicitValue.length > 0 {
+                entry.rangeStart = Int(explicitValue as String)!;
+                sourceAccountStartIndex = -1;
+              } else {
+                sourceAccountStartIndex = index; index += 1;
+              }
+            case "#se":
+              if explicitValue.length > 0 {
+                entry.rangeEnd = Int(explicitValue as String)!;
+                sourceAccountEndIndex = -1;
+              } else {
+                sourceAccountEndIndex = index; index += 1;
+              }
+            case "#tc":
+              if explicitValue.length > 0 {
+                entry.bankCode = Int(explicitValue as String)!;
+                targetBankCodeIndex = -1;
+              } else {
+                targetBankCodeIndex = index; index += 1;
+              }
+            case "#ta":
+              if explicitValue.length > 0 {
+                entry.account = Int(explicitValue as String)!;
+                targetAccountIndex = -1;
+              } else {
+                targetAccountIndex = index; index += 1;
+              }
+
+            default:
+              index += 1;
+              continue;
+            }
+          }
+
+          continue;
+        }
+
+        // Normal mapping line.
+        let parts: [String] = s.components(separatedBy: CharacterSet.whitespaces) ;
+        if sourceBankCodeIndex > -1 && sourceBankCodeIndex < parts.count {
+          sourceBankCode = parts[sourceBankCodeIndex] as NSString;
+        }
+        if sourceAccountIndex > -1 && sourceAccountIndex < parts.count {
+          entry.rangeStart = Int(parts[sourceAccountIndex])!;
+          entry.rangeEnd = entry.rangeStart;
+        }
+        if sourceAccountStartIndex > -1 && sourceAccountStartIndex < parts.count {
+          entry.rangeStart = Int(parts[sourceAccountStartIndex])!;
+        }
+        if sourceAccountEndIndex > -1 && sourceAccountEndIndex < parts.count {
+          entry.rangeEnd = Int(parts[sourceAccountEndIndex])!;
+        }
+        if targetBankCodeIndex > -1 && targetBankCodeIndex < parts.count {
+          entry.bankCode = Int(parts[targetBankCodeIndex])!;
+        }
+        if targetAccountIndex > -1 && targetAccountIndex < parts.count {
+          entry.account = Int(parts[targetAccountIndex])!;
+        }
+
+        // There can never be multiple IBAN rules for a given bank code as every bank code is
+        // covered by exactly one rule (or none at all).
+        // The source bank code can actually be a list of bank codes.
+        for bankCode in sourceBankCode.components(separatedBy: ",") {
+          let code = Int(bankCode)!;
+          var mappingTuple = _mappings[code];
+          if mappingTuple == nil {
+            mappingTuple = (rule, []);
+          }
+          mappingTuple!.details.append(entry);
+          _mappings[code] = mappingTuple;
+        }
       }
     }
   }

--- a/Source/DERules.swift
+++ b/Source/DERules.swift
@@ -18,7 +18,6 @@
  */
 
 import Foundation
-import AppKit
 
 // IBAN conversion rules specific to Germany.
 
@@ -196,9 +195,7 @@ internal class DERules : IBANRules {
           }
         }
       } catch let error as NSError {
-        let alert = NSAlert.init(error: error);
-        alert.runModal();
-        return;
+        fatalError("Failed to load data \(error)")
       }
     }
 
@@ -253,9 +250,7 @@ internal class DERules : IBANRules {
           _bicToBankCode[entry.bic] = bankCode; // Note: this is not unique! There can be more than one bank code for a BIC.
         }
       } catch let error as NSError {
-        let alert = NSAlert.init(error: error);
-        alert.runModal();
-        return;
+        fatalError("Failed to load DERCodes.txt \(error)")
       }
 
 

--- a/Tests/AccountCheckDETests.swift
+++ b/Tests/AccountCheckDETests.swift
@@ -18,7 +18,12 @@
 */
 
 import XCTest
+
+#if os(macOS)
 import IBANtools
+#else
+import IBANtools_iOS
+#endif
 
 class AccountCheckDETests: XCTestCase {
 

--- a/Tests/IBANtoolsDETests.swift
+++ b/Tests/IBANtoolsDETests.swift
@@ -18,7 +18,12 @@
 */
 
 import XCTest
+
+#if os(macOS)
 import IBANtools
+#else
+import IBANtools_iOS
+#endif
 
 class IBANtoolsDETests: XCTestCase {
 

--- a/Tests/IBANtoolsTests.swift
+++ b/Tests/IBANtoolsTests.swift
@@ -17,9 +17,15 @@
  * 02110-1301  USA
  */
 
-import Cocoa
 import XCTest
+
+#if os(macOS)
+import Cocoa
 import IBANtools
+#else
+import Foundation
+import IBANtools_iOS
+#endif
 
 class IBANtoolsTests: XCTestCase {
 


### PR DESCRIPTION
Firstly, thank you very much for this library. I was looking for exactly this library for iOS.
I have added an iOS framework target by doing the following:
* Convert NSAlerts to fatalErrors. I think crashing is nicer than displaying an error in a host app, a hard crash here tells the developer immediately that something is wrong.
* Added a compile-time switch to the tests so they work on both iOS and OSX.

The rest is all just boilerplate iOS project stuff. 

All tests work on both platforms.

I have this linked in an iOS app and it works fine although I am using just the IBAN validation part of the library. 