### PR TITLE
Fix unwrap crash when invalid characters are entered

### DIFF
--- a/Source/Converter.swift
+++ b/Source/Converter.swift
@@ -514,7 +514,7 @@ open class IBANtools: NSObject {
   fileprivate class func mod97(_ s: String) -> Int {
     var result = 0;
     for c in s {
-      let i = Int(String(c))!;
+      guard let i = Int(String(c)) else { return 0 }
       result = (result * 10 + i) % 97;
     }
     return result;


### PR DESCRIPTION
Crash occurs in our application due to users entering invalid characters when filling out IBANs (which are validated using this code)
I believe zero will work here, it would be the same result as if there were zero characters entered. 